### PR TITLE
always retain auth events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 *.swp
 ~/rustcache/*
+.idea


### PR DESCRIPTION
retain auth messages by default for async processing

also fix the Drop implementation so we don't delete the endpoint security client
when dropping the Arc.  Only when all refcounts are dropped, we delete the
endpoint security client.
